### PR TITLE
Exception day queries

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -362,6 +362,33 @@
             "deprecationReason": null
           },
           {
+            "name": "exceptionDays",
+            "description": "",
+            "args": [
+              {
+                "name": "year",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": { "kind": "OBJECT", "name": "ExceptionDay", "ofType": null }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "journey",
             "description": "",
             "args": [
@@ -2341,6 +2368,109 @@
               "name": null,
               "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
             },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExceptionDay",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exceptionDate",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Date", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "newDayType",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dayType",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "modeScope",
+            "description": "",
+            "args": [],
+            "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "",
+            "args": [],
+            "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exclusive",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Boolean", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": "",
+            "args": [],
+            "type": { "kind": "SCALAR", "name": "Time", "ofType": null },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": "",
+            "args": [],
+            "type": { "kind": "SCALAR", "name": "Time", "ofType": null },
             "isDeprecated": false,
             "deprecationReason": null
           }

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -2447,6 +2447,18 @@
             "deprecationReason": null
           },
           {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "exclusive",
             "description": "",
             "args": [],

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "graphql-codegen-typescript-server": "0.18.0",
     "husky": "^1.3.1",
     "jest": "^24.3.1",
+    "jest-haste-map": "^24.5.0",
+    "jest-resolve": "^24.5.0",
     "lint-staged": "^8.1.5",
     "nodemon": "^1.18.10",
     "prettier": "^1.16.4",

--- a/src/app/createEquipmentResponse.ts
+++ b/src/app/createEquipmentResponse.ts
@@ -46,24 +46,28 @@ export async function createEquipmentResponse(
   }
 
   const equipmentCacheKey = `equipment`
-  const equipment = await cacheFetch<Equipment[]>(equipmentCacheKey, fetchEquipment, 24 * 60 * 60)
+  const equipmentData = await cacheFetch<Equipment[]>(
+    equipmentCacheKey,
+    fetchEquipment,
+    24 * 60 * 60
+  )
 
-  if (!equipment) {
+  if (!equipmentData) {
     return []
   }
 
   if (!filter && !date) {
-    return orderBy(equipment, ['operatorId', 'vehicleId'], ['asc', 'asc'])
+    return orderBy(equipmentData, ['operatorId', 'vehicleId'], ['asc', 'asc'])
   }
 
   const vehicleIdFilter = get(filter, 'vehicleId', '')
   const operatorIdFilter = get(filter, 'operatorId', '')
   const searchFilter = get(filter, 'search', '')
 
-  let filteredEquipment = equipment
+  let filteredEquipment = equipmentData
 
   if (vehicleIdFilter && operatorIdFilter) {
-    filteredEquipment = equipment.filter(
+    filteredEquipment = equipmentData.filter(
       (item) => item.operatorId === operatorIdFilter && item.vehicleId === vehicleIdFilter
     )
   } else if (searchFilter || (vehicleIdFilter || operatorIdFilter)) {

--- a/src/app/createExceptionDaysResponse.ts
+++ b/src/app/createExceptionDaysResponse.ts
@@ -70,7 +70,7 @@ export const createExceptionDaysResponse = async (
   }
 
   const cacheKey = `exception_days_${year}`
-  const exceptionDays = await cacheFetch<ExceptionDay[]>(cacheKey, fetchData, 1)
+  const exceptionDays = await cacheFetch<ExceptionDay[]>(cacheKey, fetchData, 24 * 60 * 60)
 
   if (!exceptionDays) {
     return []

--- a/src/app/createExceptionDaysResponse.ts
+++ b/src/app/createExceptionDaysResponse.ts
@@ -1,0 +1,80 @@
+import { CachedFetcher } from '../types/CachedFetcher'
+import { ExceptionDay } from '../types/generated/schema-types'
+import {
+  ExceptionDay as ExceptionDayDescriptor,
+  ExceptionDaysCalendar,
+  ReplacementDaysCalendar,
+  ExceptionDaysCalendarsConnection,
+  ExceptionDaysConnection,
+  ReplacementDaysCalendarsConnection,
+} from '../types/generated/jore-types'
+import { isSameYear } from 'date-fns'
+import { cacheFetch } from './cache'
+import { get, orderBy, compact } from 'lodash'
+import { createExceptionDayObject } from './objects/createExceptionDayObject'
+
+type JoreExceptionQueryResponse = {
+  exceptionDayIndex: ExceptionDaysConnection
+  exceptionDays: ExceptionDaysCalendarsConnection
+  replacementDays: ReplacementDaysCalendarsConnection
+}
+
+export const createExceptionDaysResponse = async (
+  getExceptionData: () => Promise<JoreExceptionQueryResponse>,
+  year
+) => {
+  const fetchData: CachedFetcher<ExceptionDay[]> = async () => {
+    const exceptionData = await getExceptionData()
+
+    if (!exceptionData) {
+      return false
+    }
+
+    const {
+      exceptionDayIndex: { nodes: exceptionDayDescriptionNodes },
+      exceptionDays: { nodes: exceptionDayNodes },
+      replacementDays: { nodes: replacementDayNodes },
+    } = exceptionData
+
+    const exceptionDayIndex: ExceptionDayDescriptor[] = compact(exceptionDayDescriptionNodes || [])
+    const joreExceptionDays: ExceptionDaysCalendar[] = compact(exceptionDayNodes || [])
+    const joreReplacementDays: ReplacementDaysCalendar[] = compact(replacementDayNodes || [])
+
+    const exceptionDayObjects = joreExceptionDays.reduce((days: ExceptionDay[], day) => {
+      const description = exceptionDayIndex.find(
+        (dayDescriptor) =>
+          get(dayDescriptor, 'exceptionDayType', '') === get(day, 'exceptionDayType', null)
+      )
+
+      const dayObject = createExceptionDayObject(day, description)
+
+      if (dayObject) {
+        days.push(dayObject)
+      }
+
+      return days
+    }, [])
+
+    const replacementDayObjects = joreReplacementDays.reduce((days: ExceptionDay[], day) => {
+      const dayObject = createExceptionDayObject(day)
+
+      if (dayObject) {
+        days.push(dayObject)
+      }
+
+      return days
+    }, [])
+
+    const combinedDays = orderBy(exceptionDayObjects.concat(replacementDayObjects), 'exceptionDate')
+    return combinedDays.filter((day) => isSameYear(day.exceptionDate, year))
+  }
+
+  const cacheKey = `exception_days_${year}`
+  const exceptionDays = await cacheFetch<ExceptionDay[]>(cacheKey, fetchData, 1)
+
+  if (!exceptionDays) {
+    return []
+  }
+
+  return exceptionDays
+}

--- a/src/app/objects/createExceptionDayObject.ts
+++ b/src/app/objects/createExceptionDayObject.ts
@@ -1,0 +1,42 @@
+import {
+  ExceptionDay as ExceptionDayDescriptor,
+  ExceptionDaysCalendar,
+  ReplacementDaysCalendar,
+} from '../../types/generated/jore-types'
+import { ExceptionDay } from '../../types/generated/schema-types'
+import { get } from 'lodash'
+
+function isReplacementDay(
+  item: ExceptionDaysCalendar | ReplacementDaysCalendar
+): item is ReplacementDaysCalendar {
+  return (item as ReplacementDaysCalendar).scope !== undefined
+}
+
+function isExceptionDay(
+  item: ExceptionDaysCalendar | ReplacementDaysCalendar
+): item is ExceptionDaysCalendar {
+  return (item as ExceptionDaysCalendar).exclusive !== undefined
+}
+
+export const createExceptionDayObject = (
+  config: ReplacementDaysCalendar | ExceptionDaysCalendar | null,
+  description?: ExceptionDayDescriptor | null
+): ExceptionDay | null => {
+  if (!config) {
+    return null
+  }
+
+  return {
+    id: `exception_day_${isReplacementDay(config) ? 'replacement' : 'exception'}_${
+      config.dayType
+    }_${config.dateInEffect}`,
+    dayType: config.dayType,
+    description: description ? get(description, 'description', '') : '',
+    exceptionDate: config.dateInEffect,
+    exclusive: isExceptionDay(config) ? config.exclusive === 1 : false,
+    modeScope: isReplacementDay(config) ? config.scope : '',
+    newDayType: isExceptionDay(config) ? config.exceptionDayType : config.replacingDayType,
+    startTime: isReplacementDay(config) ? config.timeBegin : null,
+    endTime: isReplacementDay(config) ? config.timeEnd : null,
+  }
+}

--- a/src/app/objects/createExceptionDayObject.ts
+++ b/src/app/objects/createExceptionDayObject.ts
@@ -18,6 +18,23 @@ function isExceptionDay(
   return (item as ExceptionDaysCalendar).exclusive !== undefined
 }
 
+function getMode(code) {
+  switch (code) {
+    case '02':
+      return 'TRAM'
+    case '06':
+      return 'SUBWAY'
+    case '07':
+      return 'FERRY'
+    case '12':
+      return 'RAIL'
+    case '13':
+      return 'RAIL'
+    default:
+      return 'BUS'
+  }
+}
+
 export const createExceptionDayObject = (
   config: ReplacementDaysCalendar | ExceptionDaysCalendar | null,
   description?: ExceptionDayDescriptor | null
@@ -34,7 +51,7 @@ export const createExceptionDayObject = (
     description: description ? get(description, 'description', '') : '',
     exceptionDate: config.dateInEffect,
     exclusive: isExceptionDay(config) ? config.exclusive === 1 : false,
-    modeScope: isReplacementDay(config) ? config.scope : '',
+    modeScope: isReplacementDay(config) ? getMode(config.scope) : '',
     newDayType: isExceptionDay(config) ? config.exceptionDayType : config.replacingDayType,
     startTime: isReplacementDay(config) ? config.timeBegin : null,
     endTime: isReplacementDay(config) ? config.timeEnd : null,

--- a/src/app/objects/createExceptionDayObject.ts
+++ b/src/app/objects/createExceptionDayObject.ts
@@ -51,6 +51,7 @@ export const createExceptionDayObject = (
     description: description ? get(description, 'description', '') : '',
     exceptionDate: config.dateInEffect,
     exclusive: isExceptionDay(config) ? config.exclusive === 1 : false,
+    type: isExceptionDay(config) ? 'exception' : 'replacement',
     modeScope: isReplacementDay(config) ? getMode(config.scope) : '',
     newDayType: isExceptionDay(config) ? config.exceptionDayType : config.replacingDayType,
     startTime: isReplacementDay(config) ? config.timeBegin : null,

--- a/src/datasources/ExceptionDataSource.ts
+++ b/src/datasources/ExceptionDataSource.ts
@@ -1,0 +1,22 @@
+import { GraphQLDataSource } from '../utils/GraphQLDataSource'
+import { get } from 'lodash'
+import { JORE_URL } from '../constants'
+import { EXCEPTION_DAYS_QUERY } from '../queries/exceptionDayQueries'
+
+export class ExceptionDataSource extends GraphQLDataSource {
+  baseURL = JORE_URL
+
+  async getExceptionDaysForYear(year) {
+    if (!year) {
+      return null
+    }
+
+    const response = await this.query(EXCEPTION_DAYS_QUERY, {
+      variables: {
+        year,
+      },
+    })
+
+    return get(response, 'data', {})
+  }
+}

--- a/src/datasources/JoreDataSource.ts
+++ b/src/datasources/JoreDataSource.ts
@@ -23,6 +23,7 @@ import { EQUIPMENT, EQUIPMENT_BY_ID } from '../queries/equipmentQueries'
 import { getDayTypeFromDate } from '../utils/getDayTypeFromDate'
 import { filterByDateChains } from '../utils/filterByDateChains'
 import { DEPARTURE_STOP, DEPARTURES_FOR_STOP_QUERY } from '../queries/departureQueries'
+import { EXCEPTION_DAYS_QUERY } from '../queries/exceptionDayQueries'
 
 export class JoreDataSource extends GraphQLDataSource {
   baseURL = JORE_URL
@@ -188,5 +189,19 @@ export class JoreDataSource extends GraphQLDataSource {
     })
 
     return get(response, 'data.allDepartures.nodes', null)
+  }
+
+  async getExceptionDaysForYear(year) {
+    if (!year) {
+      return null
+    }
+
+    const response = await this.query(EXCEPTION_DAYS_QUERY, {
+      variables: {
+        year,
+      },
+    })
+
+    return get(response, 'data', {})
   }
 }

--- a/src/queries/exceptionDayQueries.ts
+++ b/src/queries/exceptionDayQueries.ts
@@ -1,0 +1,30 @@
+import { gql } from 'apollo-server'
+
+export const EXCEPTION_DAYS_QUERY = gql`
+  query JoreExceptionDays {
+    exceptionDayIndex: allExceptionDays {
+      nodes {
+        description
+        exceptionDayType
+      }
+    }
+    exceptionDays: allExceptionDaysCalendars {
+      nodes {
+        dateInEffect
+        dayType
+        exceptionDayType
+        exclusive
+      }
+    }
+    replacementDays: allReplacementDaysCalendars {
+      nodes {
+        dateInEffect
+        dayType
+        replacingDayType
+        scope
+        timeBegin
+        timeEnd
+      }
+    }
+  }
+`

--- a/src/resolvers/queryResolvers.ts
+++ b/src/resolvers/queryResolvers.ts
@@ -10,6 +10,7 @@ import { getNormalTime } from '../utils/time'
 import { createRouteSegmentsResponse } from '../app/createRouteSegmentsResponse'
 import { createVehicleJourneysResponse } from '../app/createVehicleJourneysResponse'
 import { createAreaJourneysResponse } from '../app/createAreaJourneysResponse'
+import { createExceptionDaysResponse } from '../app/createExceptionDaysResponse'
 
 const equipment = (root, { filter, date }, { dataSources }) => {
   const getEquipment = () => dataSources.JoreAPI.getEquipment()
@@ -106,6 +107,11 @@ const eventsByBbox = (root, { minTime, maxTime, bbox, date, filters }, { dataSou
   return createAreaJourneysResponse(getAreaJourneys, minTime, maxTime, bbox, date, filters)
 }
 
+const exceptionDays = (root, { year }, { dataSources }) => {
+  const getExceptionData = () => dataSources.JoreAPI.getExceptionDaysForYear(year)
+  return createExceptionDaysResponse(getExceptionData, year)
+}
+
 export const queryResolvers: QueryResolvers.Resolvers = {
   equipment,
   stop,
@@ -120,4 +126,5 @@ export const queryResolvers: QueryResolvers.Resolvers = {
   journey,
   vehicleJourneys,
   eventsByBbox,
+  exceptionDays,
 }

--- a/src/resolvers/queryResolvers.ts
+++ b/src/resolvers/queryResolvers.ts
@@ -11,6 +11,7 @@ import { createRouteSegmentsResponse } from '../app/createRouteSegmentsResponse'
 import { createVehicleJourneysResponse } from '../app/createVehicleJourneysResponse'
 import { createAreaJourneysResponse } from '../app/createAreaJourneysResponse'
 import { createExceptionDaysResponse } from '../app/createExceptionDaysResponse'
+import { getExceptions } from '../utils/getExceptions'
 
 const equipment = (root, { filter, date }, { dataSources }) => {
   const getEquipment = () => dataSources.JoreAPI.getEquipment()
@@ -107,9 +108,8 @@ const eventsByBbox = (root, { minTime, maxTime, bbox, date, filters }, { dataSou
   return createAreaJourneysResponse(getAreaJourneys, minTime, maxTime, bbox, date, filters)
 }
 
-const exceptionDays = (root, { year }, { dataSources }) => {
-  const getExceptionData = () => dataSources.JoreAPI.getExceptionDaysForYear(year)
-  return createExceptionDaysResponse(getExceptionData, year)
+const exceptionDays = (root, { year }) => {
+  return getExceptions(year)
 }
 
 export const queryResolvers: QueryResolvers.Resolvers = {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,5 +5,6 @@ import { Departure } from './schema/Departure'
 import { Journey } from './schema/Journey'
 import { Equipment } from './schema/Equipment'
 import { Line } from './schema/Line'
+import { ExceptionDays } from './schema/ExceptionDay'
 
-export default [Route, Line, Stop, Departure, Journey, Equipment, Schema]
+export default [Route, Line, Stop, Departure, Journey, Equipment, ExceptionDays, Schema]

--- a/src/schema/ExceptionDay.ts
+++ b/src/schema/ExceptionDay.ts
@@ -8,6 +8,7 @@ export const ExceptionDays = gql`
     dayType: String!
     modeScope: String
     description: String
+    type: String!
     exclusive: Boolean!
     startTime: Time
     endTime: Time

--- a/src/schema/ExceptionDay.ts
+++ b/src/schema/ExceptionDay.ts
@@ -1,0 +1,15 @@
+import { gql } from 'apollo-server'
+
+export const ExceptionDays = gql`
+  type ExceptionDay {
+    id: ID!
+    exceptionDate: Date!
+    newDayType: String!
+    dayType: String!
+    modeScope: String
+    description: String
+    exclusive: Boolean!
+    startTime: Time
+    endTime: Time
+  }
+`

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -32,6 +32,7 @@ export const Schema = gql`
     routeSegments(routeId: String!, direction: Direction!, date: Date!): [RouteSegment]!
     lines(filter: LineFilterInput, date: Date, includeLinesWithoutRoutes: Boolean = false): [Line]!
     departures(filter: DepartureFilterInput, stopId: String!, date: Date!): [Departure]!
+    exceptionDays(year: String!): [ExceptionDay]!
     journey(
       routeId: String!
       direction: Direction!

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { ApolloServer } from 'apollo-server'
 import { resolvers } from './resolvers/'
 import { JoreDataSource } from './datasources/JoreDataSource'
 import { HFPDataSource } from './datasources/HFPDataSource'
+import { ExceptionDataSource } from './datasources/ExceptionDataSource'
 
 const server = new ApolloServer({
   typeDefs: schema,
@@ -15,6 +16,7 @@ const server = new ApolloServer({
   dataSources: () => ({
     JoreAPI: new JoreDataSource(),
     HFPAPI: new HFPDataSource(),
+    ExceptionAPI: new ExceptionDataSource(),
   }),
 })
 

--- a/src/types/generated/jore-types.ts
+++ b/src/types/generated/jore-types.ts
@@ -192,7 +192,7 @@ export interface EquipmentCondition {
 /** A condition to be used against `ExceptionDay` object types. All fields are tested for equality and combined with a logical ‘and.’ */
 export interface ExceptionDayCondition {
   /** Checks for equality with the object’s `exceptionDayType` field. */
-  exceptionDayType?: Maybe<Date>
+  exceptionDayType?: Maybe<string>
   /** Checks for equality with the object’s `description` field. */
   description?: Maybe<string>
 }
@@ -1436,7 +1436,7 @@ export interface ExceptionDay extends Node {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: string
 
-  exceptionDayType: Date
+  exceptionDayType: string
 
   description?: Maybe<string>
 }
@@ -1927,7 +1927,7 @@ export interface EquipmentByRegistryNrQueryArgs {
   registryNr: string
 }
 export interface ExceptionDayByExceptionDayTypeQueryArgs {
-  exceptionDayType: Date
+  exceptionDayType: string
 }
 export interface ExceptionDaysCalendarByDateInEffectQueryArgs {
   dateInEffect: Date

--- a/src/types/generated/resolver-types.ts
+++ b/src/types/generated/resolver-types.ts
@@ -136,6 +136,8 @@ export namespace QueryResolvers {
 
     departures?: DeparturesResolver<Array<Maybe<Departure>>, TypeParent, TContext>
 
+    exceptionDays?: ExceptionDaysResolver<Array<Maybe<ExceptionDay>>, TypeParent, TContext>
+
     journey?: JourneyResolver<Maybe<Journey>, TypeParent, TContext>
 
     vehicleJourneys?: VehicleJourneysResolver<Array<Maybe<VehicleJourney>>, TypeParent, TContext>
@@ -268,6 +270,15 @@ export namespace QueryResolvers {
     stopId: string
 
     date: Date
+  }
+
+  export type ExceptionDaysResolver<
+    R = Array<Maybe<ExceptionDay>>,
+    Parent = {},
+    TContext = {}
+  > = Resolver<R, Parent, TContext, ExceptionDaysArgs>
+  export interface ExceptionDaysArgs {
+    year: string
   }
 
   export type JourneyResolver<R = Maybe<Journey>, Parent = {}, TContext = {}> = Resolver<
@@ -1304,6 +1315,74 @@ export namespace ObservedDepartureResolvers {
   > = Resolver<R, Parent, TContext>
 }
 
+export namespace ExceptionDayResolvers {
+  export interface Resolvers<TContext = {}, TypeParent = ExceptionDay> {
+    id?: IdResolver<string, TypeParent, TContext>
+
+    exceptionDate?: ExceptionDateResolver<Date, TypeParent, TContext>
+
+    newDayType?: NewDayTypeResolver<string, TypeParent, TContext>
+
+    dayType?: DayTypeResolver<string, TypeParent, TContext>
+
+    modeScope?: ModeScopeResolver<Maybe<string>, TypeParent, TContext>
+
+    description?: DescriptionResolver<Maybe<string>, TypeParent, TContext>
+
+    exclusive?: ExclusiveResolver<boolean, TypeParent, TContext>
+
+    startTime?: StartTimeResolver<Maybe<Time>, TypeParent, TContext>
+
+    endTime?: EndTimeResolver<Maybe<Time>, TypeParent, TContext>
+  }
+
+  export type IdResolver<R = string, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type ExceptionDateResolver<R = Date, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type NewDayTypeResolver<R = string, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type DayTypeResolver<R = string, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type ModeScopeResolver<R = Maybe<string>, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type DescriptionResolver<
+    R = Maybe<string>,
+    Parent = ExceptionDay,
+    TContext = {}
+  > = Resolver<R, Parent, TContext>
+  export type ExclusiveResolver<R = boolean, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type StartTimeResolver<R = Maybe<Time>, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type EndTimeResolver<R = Maybe<Time>, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+}
+
 export namespace JourneyResolvers {
   export interface Resolvers<TContext = {}, TypeParent = Journey> {
     id?: IdResolver<string, TypeParent, TContext>
@@ -1731,6 +1810,7 @@ export type IResolvers<TContext = {}> = {
   JourneyEvent?: JourneyEventResolvers.Resolvers<TContext>
   PlannedDeparture?: PlannedDepartureResolvers.Resolvers<TContext>
   ObservedDeparture?: ObservedDepartureResolvers.Resolvers<TContext>
+  ExceptionDay?: ExceptionDayResolvers.Resolvers<TContext>
   Journey?: JourneyResolvers.Resolvers<TContext>
   VehicleJourney?: VehicleJourneyResolvers.Resolvers<TContext>
   AreaJourney?: AreaJourneyResolvers.Resolvers<TContext>

--- a/src/types/generated/resolver-types.ts
+++ b/src/types/generated/resolver-types.ts
@@ -1329,6 +1329,8 @@ export namespace ExceptionDayResolvers {
 
     description?: DescriptionResolver<Maybe<string>, TypeParent, TContext>
 
+    type?: TypeResolver<string, TypeParent, TContext>
+
     exclusive?: ExclusiveResolver<boolean, TypeParent, TContext>
 
     startTime?: StartTimeResolver<Maybe<Time>, TypeParent, TContext>
@@ -1366,6 +1368,11 @@ export namespace ExceptionDayResolvers {
     Parent = ExceptionDay,
     TContext = {}
   > = Resolver<R, Parent, TContext>
+  export type TypeResolver<R = string, Parent = ExceptionDay, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
   export type ExclusiveResolver<R = boolean, Parent = ExceptionDay, TContext = {}> = Resolver<
     R,
     Parent,

--- a/src/types/generated/schema-types.ts
+++ b/src/types/generated/schema-types.ts
@@ -111,6 +111,8 @@ export interface Query {
 
   departures: Array<Maybe<Departure>>
 
+  exceptionDays: Array<Maybe<ExceptionDay>>
+
   journey?: Maybe<Journey>
 
   vehicleJourneys: Array<Maybe<VehicleJourney>>
@@ -412,6 +414,26 @@ export interface ObservedDeparture {
   departureTimeDifference: number
 }
 
+export interface ExceptionDay {
+  id: string
+
+  exceptionDate: Date
+
+  newDayType: string
+
+  dayType: string
+
+  modeScope?: Maybe<string>
+
+  description?: Maybe<string>
+
+  exclusive: boolean
+
+  startTime?: Maybe<Time>
+
+  endTime?: Maybe<Time>
+}
+
 export interface Journey {
   id: string
 
@@ -573,6 +595,9 @@ export interface DeparturesQueryArgs {
   stopId: string
 
   date: Date
+}
+export interface ExceptionDaysQueryArgs {
+  year: string
 }
 export interface JourneyQueryArgs {
   routeId: string

--- a/src/types/generated/schema-types.ts
+++ b/src/types/generated/schema-types.ts
@@ -427,6 +427,8 @@ export interface ExceptionDay {
 
   description?: Maybe<string>
 
+  type: string
+
   exclusive: boolean
 
   startTime?: Maybe<Time>

--- a/src/utils/getExceptions.ts
+++ b/src/utils/getExceptions.ts
@@ -1,0 +1,81 @@
+import { ExceptionDataSource } from '../datasources/ExceptionDataSource'
+import { CachedFetcher } from '../types/CachedFetcher'
+import { ExceptionDay } from '../types/generated/schema-types'
+import {
+  ExceptionDay as ExceptionDayDescriptor,
+  ExceptionDaysCalendar,
+  ReplacementDaysCalendar,
+} from '../types/generated/jore-types'
+import { createExceptionDayObject } from '../app/objects/createExceptionDayObject'
+import { isSameYear } from 'date-fns'
+import { cacheFetch } from '../app/cache'
+import { compact, get, orderBy } from 'lodash'
+
+let dataSource: null | ExceptionDataSource = null
+
+const fetchExceptions: CachedFetcher<ExceptionDay[]> = async (year) => {
+  if (!dataSource) {
+    dataSource = new ExceptionDataSource()
+  }
+
+  const exceptionData = await dataSource.getExceptionDaysForYear(year)
+
+  if (!exceptionData) {
+    return false
+  }
+
+  const {
+    exceptionDayIndex: { nodes: exceptionDayDescriptionNodes },
+    exceptionDays: { nodes: exceptionDayNodes },
+    replacementDays: { nodes: replacementDayNodes },
+  } = exceptionData
+
+  const exceptionDayIndex: ExceptionDayDescriptor[] = compact(exceptionDayDescriptionNodes || [])
+  const joreExceptionDays: ExceptionDaysCalendar[] = compact(exceptionDayNodes || [])
+  const joreReplacementDays: ReplacementDaysCalendar[] = compact(replacementDayNodes || [])
+
+  const exceptionDayObjects = joreExceptionDays.reduce((days: ExceptionDay[], day) => {
+    const description = exceptionDayIndex.find(
+      (dayDescriptor) =>
+        get(dayDescriptor, 'exceptionDayType', '') === get(day, 'exceptionDayType', null)
+    )
+
+    const dayObject = createExceptionDayObject(day, description)
+
+    if (dayObject) {
+      days.push(dayObject)
+    }
+
+    return days
+  }, [])
+
+  const replacementDayObjects = joreReplacementDays.reduce((days: ExceptionDay[], day) => {
+    const dayObject = createExceptionDayObject(day)
+
+    if (dayObject) {
+      days.push(dayObject)
+    }
+
+    return days
+  }, [])
+
+  const combinedDays = orderBy(exceptionDayObjects.concat(replacementDayObjects), 'exceptionDate')
+  return combinedDays.filter((day) => isSameYear(day.exceptionDate, year))
+}
+
+export const getExceptions = async (year) => {
+  const cacheKey = `exception_days_${year}`
+  const exceptionDays = await cacheFetch<ExceptionDay[]>(
+    cacheKey,
+    () => fetchExceptions(year),
+    30 * 24 * 60 * 60
+  )
+
+  if (!exceptionDays) {
+    return []
+  }
+
+  return exceptionDays
+}
+
+export const getExceptionForDate = async (date: Date) => {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,16 @@
     jest-message-util "^24.3.0"
     jest-mock "^24.3.0"
 
+"@jest/fake-timers@^24.5.0":
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.5.0.tgz#4a29678b91fd0876144a58f8d46e6c62de0266f0"
+  integrity sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==
+  dependencies:
+    "@jest/types" "^24.5.0"
+    "@types/node" "*"
+    jest-message-util "^24.5.0"
+    jest-mock "^24.5.0"
+
 "@jest/reporters@^24.3.1":
   version "24.3.1"
   resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.3.1.tgz#68e4abc8d4233acd0dd87287f3bd270d81066248"
@@ -266,6 +276,15 @@
     "@jest/types" "^24.3.0"
     "@types/istanbul-lib-coverage" "^1.1.0"
 
+"@jest/test-result@^24.5.0":
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.5.0.tgz#ab66fb7741a04af3363443084e72ea84861a53f2"
+  integrity sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==
+  dependencies:
+    "@jest/console" "^24.3.0"
+    "@jest/types" "^24.5.0"
+    "@types/istanbul-lib-coverage" "^1.1.0"
+
 "@jest/transform@^24.3.1":
   version "24.3.1"
   resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.3.1.tgz#ce9e1329eb5e640f493bcd5c8eb9970770959bfc"
@@ -291,6 +310,14 @@
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.3.0.tgz#3f6e117e47248a9a6b5f1357ec645bd364f7ad23"
   integrity sha512-VoO1F5tU2n/93QN/zaZ7Q8SeV/Rj+9JJOgbvKbBwy4lenvmdj1iDaQEPXGTKrO6OSvDeb2drTFipZJYxgo6kIQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^1.1.0"
+    "@types/yargs" "^12.0.9"
+
+"@jest/types@^24.5.0":
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.5.0.tgz#feee214a4d0167b0ca447284e95a57aa10b3ee95"
+  integrity sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==
   dependencies:
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
@@ -4284,6 +4311,21 @@ jest-haste-map@^24.3.1:
     micromatch "^3.1.10"
     sane "^4.0.3"
 
+jest-haste-map@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.5.0.tgz#3f17d0c548b99c0c96ed2893f9c0ccecb2eb9066"
+  integrity sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==
+  dependencies:
+    "@jest/types" "^24.5.0"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.15"
+    invariant "^2.2.4"
+    jest-serializer "^24.4.0"
+    jest-util "^24.5.0"
+    jest-worker "^24.4.0"
+    micromatch "^3.1.10"
+    sane "^4.0.3"
+
 jest-jasmine2@^24.3.1:
   version "24.3.1"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.3.1.tgz#127d628d3ac0829bd3c0fccacb87193e543b420b"
@@ -4337,12 +4379,38 @@ jest-message-util@^24.3.0:
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
+jest-message-util@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.5.0.tgz#181420a65a7ef2e8b5c2f8e14882c453c6d41d07"
+  integrity sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^24.5.0"
+    "@jest/types" "^24.5.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^2.0.1"
+    micromatch "^3.1.10"
+    slash "^2.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.3.0.tgz#95a86b6ad474e3e33227e6dd7c4ff6b07e18d3cb"
   integrity sha512-AhAo0qjbVWWGvcbW5nChFjR0ObQImvGtU6DodprNziDOt+pP0CBdht/sYcNIOXeim8083QUi9bC8QdKB8PTK4Q==
   dependencies:
     "@jest/types" "^24.3.0"
+
+jest-mock@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.5.0.tgz#976912c99a93f2a1c67497a9414aa4d9da4c7b76"
+  integrity sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==
+  dependencies:
+    "@jest/types" "^24.5.0"
+
+jest-pnp-resolver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
+  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
 jest-regex-util@^24.3.0:
   version "24.3.0"
@@ -4366,6 +4434,17 @@ jest-resolve@^24.3.1:
     "@jest/types" "^24.3.0"
     browser-resolve "^1.11.3"
     chalk "^2.0.1"
+    realpath-native "^1.1.0"
+
+jest-resolve@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.5.0.tgz#8c16ba08f60a1616c3b1cd7afb24574f50a24d04"
+  integrity sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==
+  dependencies:
+    "@jest/types" "^24.5.0"
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    jest-pnp-resolver "^1.2.1"
     realpath-native "^1.1.0"
 
 jest-runner@^24.3.1:
@@ -4427,6 +4506,11 @@ jest-serializer@^24.3.0:
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.3.0.tgz#074e307300d1451617cf2630d11543ee4f74a1c8"
   integrity sha512-RiSpqo2OFbVLJN/PgAOwQIUeHDfss6NBUDTLhjiJM8Bb5rMrwRqHfkaqahIsOf9cXXB5UjcqDCzbQ7AIoMqWkg==
 
+jest-serializer@^24.4.0:
+  version "24.4.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.4.0.tgz#f70c5918c8ea9235ccb1276d232e459080588db3"
+  integrity sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==
+
 jest-snapshot@^24.3.1:
   version "24.3.1"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.3.1.tgz#0f22a86c1b8c87e823f5ad095e82c19d9ed93d72"
@@ -4455,6 +4539,25 @@ jest-util@^24.3.0:
     "@jest/source-map" "^24.3.0"
     "@jest/test-result" "^24.3.0"
     "@jest/types" "^24.3.0"
+    "@types/node" "*"
+    callsites "^3.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.15"
+    is-ci "^2.0.0"
+    mkdirp "^0.5.1"
+    slash "^2.0.0"
+    source-map "^0.6.0"
+
+jest-util@^24.5.0:
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.5.0.tgz#9d9cb06d9dcccc8e7cc76df91b1635025d7baa84"
+  integrity sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==
+  dependencies:
+    "@jest/console" "^24.3.0"
+    "@jest/fake-timers" "^24.5.0"
+    "@jest/source-map" "^24.3.0"
+    "@jest/test-result" "^24.5.0"
+    "@jest/types" "^24.5.0"
     "@types/node" "*"
     callsites "^3.0.0"
     chalk "^2.0.1"
@@ -4494,6 +4597,15 @@ jest-worker@^24.3.1:
   version "24.3.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.3.1.tgz#c1759dd2b1d5541b09a2e5e1bc3288de6c9d8632"
   integrity sha512-ZCoAe/iGLzTJvWHrO8fyx3bmEQhpL16SILJmWHKe8joHhyF3z00psF1sCRT54DoHw5GJG0ZpUtGy+ylvwA4haA==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^1.0.1"
+    supports-color "^6.1.0"
+
+jest-worker@^24.4.0:
+  version "24.4.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.4.0.tgz#fbc452b0120bb5c2a70cdc88fa132b48eeb11dd0"
+  integrity sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==
   dependencies:
     "@types/node" "*"
     merge-stream "^1.0.1"


### PR DESCRIPTION
- Implement queries which consumers can use to get info about exception days
- ~~Transparently use exception and replacement day data in departures query where dayType is used to query for the correct data for that date.~~ (< separate PR)