### PR TITLE
Fix departures WIP

### DIFF
--- a/src/app/createDeparturesResponse.ts
+++ b/src/app/createDeparturesResponse.ts
@@ -225,14 +225,7 @@ export async function createDeparturesResponse(
         `${route_id}_${direction}_${departure_id}_${stop_id}_${day_type}_${extra_departure}`
     ) as Dictionary<JoreDepartureWithOrigin[]>
 
-    let validDepartures = filterByDateChains<JoreDepartureWithOrigin>(groupedDepartures, date)
-
-    validDepartures = uniqBy(
-      validDepartures,
-      ({ route_id, direction, extra_departure, stop_id, hours, minutes }) =>
-        `${route_id}_${direction}_${extra_departure}_${stop_id}_${hours}:${minutes}`
-    )
-
+    const validDepartures = filterByDateChains<JoreDepartureWithOrigin>(groupedDepartures, date)
     return filterByExceptions(combineDeparturesAndStops(validDepartures, stops, date), exceptions)
   }
 

--- a/src/app/createJourneyResponse.ts
+++ b/src/app/createJourneyResponse.ts
@@ -144,7 +144,7 @@ const fetchJourneyDepartures: CachedFetcher<JourneyRoute> = async (
     }
 
     const stop = createRouteSegmentObject(stopSegment)
-    return createPlannedDepartureObject(departure, stop, date)
+    return createPlannedDepartureObject(departure, stop, date, 'journey')
   })
 
   // Return both the route and the departures that we put so much work into parsing.

--- a/src/app/createRouteDeparturesResponse.ts
+++ b/src/app/createRouteDeparturesResponse.ts
@@ -98,7 +98,7 @@ export const combineDeparturesAndStops = (departures, stops, date): Departure[] 
       return null
     }
 
-    return createPlannedDepartureObject(departure, stop, date)
+    return createPlannedDepartureObject(departure, stop, date, 'route')
   })
 
   return compact(departuresAndStops)

--- a/src/app/createWeekDeparturesResponse.ts
+++ b/src/app/createWeekDeparturesResponse.ts
@@ -129,14 +129,13 @@ export const combineDeparturesAndStops = (
       }
     }
 
-    return uniq(departureDates).map((departureDate) => {
-      return createPlannedDepartureObject(departure, stop, departureDate)
-    })
+    return uniq(departureDates).map((departureDate) =>
+      createPlannedDepartureObject(departure, stop, departureDate, 'weekly')
+    )
   })
 
   const allDepartures = compact(flatten(departuresWithStops))
-  const filteredDepartures = filterByExceptions(allDepartures, exceptions)
-  return filteredDepartures
+  return filterByExceptions(allDepartures, exceptions)
 }
 
 export const createWeekDeparturesResponse = async (

--- a/src/app/createWeekDeparturesResponse.ts
+++ b/src/app/createWeekDeparturesResponse.ts
@@ -42,7 +42,7 @@ const combineDeparturesAndEvents = (departures, events): Departure[] => {
         // All times are given as 24h+ times wherever possible, including here. Calculate 24h+ times
         // for the event to match it with the 24h+ time of the origin departure.
         getJourneyStartTime(event, departureIsNextDay) === departureTime &&
-        getDayTypeFromDate(event.oday) === dayType
+        (getDayTypeFromDate(event.oday) === dayType || event.oday === departureDate)
     )
 
     if (!eventsForDeparture || eventsForDeparture.length === 0) {

--- a/src/app/createWeekDeparturesResponse.ts
+++ b/src/app/createWeekDeparturesResponse.ts
@@ -13,7 +13,7 @@ import {
 } from './objects/createDepartureObject'
 import { getJourneyStartTime } from '../utils/time'
 import { getStopDepartureData } from '../utils/getStopDepartureData'
-import { get, groupBy, orderBy, compact, uniq, flatten, difference } from 'lodash'
+import { get, groupBy, orderBy, compact, uniq, flatten } from 'lodash'
 import { dayTypes, getDayTypeFromDate } from '../utils/dayTypes'
 import { fetchEvents, fetchStops } from './createDeparturesResponse'
 import { TZ } from '../constants'
@@ -115,18 +115,16 @@ export const combineDeparturesAndStops = (
       return [null]
     }
 
-    if (!dayTypeHasException) {
-      // Get the real date of this departure from within the selected week.
-      const weekDayIndex = dayTypes.indexOf(departure.day_type)
+    // Get the real date of this departure from within the selected week.
+    const weekDayIndex = dayTypes.indexOf(departure.day_type)
 
-      if (weekDayIndex !== -1) {
-        const normalDayTypeDate = weekStart
-          .clone()
-          .add(weekDayIndex, 'days')
-          .format('YYYY-MM-DD')
+    if (weekDayIndex !== -1) {
+      const normalDayTypeDate = weekStart
+        .clone()
+        .add(weekDayIndex, 'days')
+        .format('YYYY-MM-DD')
 
-        departureDates.push(normalDayTypeDate)
-      }
+      departureDates.push(normalDayTypeDate)
     }
 
     return uniq(departureDates).map((departureDate) =>
@@ -152,7 +150,7 @@ export const createWeekDeparturesResponse = async (
 
   // Fetches the departures and stop data for the stop and validates them.
   const fetchDepartures: CachedFetcher<Departure[]> = async () => {
-    const stopsCacheKey = `departure_stop_${stopId}_${date}`
+    const stopsCacheKey = `departure_stops_${stopId}_${date}`
 
     // Do NOT await these yet as we can fetch them in parallel.
     const stopsPromise = cacheFetch<RouteSegment[]>(

--- a/src/app/objects/createDepartureObject.ts
+++ b/src/app/objects/createDepartureObject.ts
@@ -83,12 +83,13 @@ export function createDepartureJourneyObject(
 export function createPlannedDepartureObject(
   departure: JoreRouteDepartureData | JoreDepartureWithOrigin,
   stop: RouteSegment,
-  departureDate: string
+  departureDate: string,
+  prefix = ''
 ): Departure {
   const departureId = createDepartureId(departure, departureDate)
 
   return {
-    id: departureId,
+    id: prefix + '/' + departureId,
     stopId: get(departure, 'stop_id', get(stop, 'stopId', '')),
     dayType: departure.day_type,
     equipmentType: departure.equipment_type,

--- a/src/app/objects/createExceptionDayObject.ts
+++ b/src/app/objects/createExceptionDayObject.ts
@@ -1,7 +1,7 @@
 import { JoreExceptionDay } from '../../types/Jore'
 import { ExceptionDay } from '../../types/generated/schema-types'
 import { getMode } from '../../utils/getMode'
-import { compact } from 'lodash'
+import { compact, uniq } from 'lodash'
 
 export const createExceptionDayObject = (config: JoreExceptionDay | null): ExceptionDay | null => {
   if (!config) {
@@ -17,7 +17,7 @@ export const createExceptionDayObject = (config: JoreExceptionDay | null): Excep
     exceptionDate: config.date_in_effect,
     exclusive: config.exclusive === 1 || false,
     modeScope: getMode(config.scope) || '',
-    effectiveDayTypes: compact(config.effective_day_types),
+    effectiveDayTypes: uniq(compact(config.effective_day_types)),
     startTime: config.time_begin || null,
     endTime: config.time_end || null,
   }

--- a/src/datasources/JoreDataSource.ts
+++ b/src/datasources/JoreDataSource.ts
@@ -460,7 +460,6 @@ ORDER BY departure.hours ASC,
       `
 SELECT ${this.departureFields}
 FROM :schema:.departure departure
-    LEFT OUTER JOIN :schema:.departure_origin_departure(departure) origin_departure ON true
 WHERE departure.stop_id = :stopId
   AND departure.route_id = :routeId
   AND departure.direction = :direction
@@ -519,7 +518,10 @@ SELECT ex_day.date_in_effect,
    rep_day.scope,
    rep_day.time_begin,
    rep_day.time_end,
-   ARRAY [ex_day.exception_day_type, rep_day.replacing_day_type] effective_day_types
+   CASE WHEN rep_day.replacing_day_type
+        IS NULL THEN ARRAY [ex_day.exception_day_type, ex_day.day_type]
+        ELSE ARRAY [ex_day.exception_day_type, rep_day.replacing_day_type]
+   END effective_day_types
 FROM :schema:.exception_days_calendar ex_day
      LEFT OUTER JOIN :schema:.exception_days ex_desc
                      ON ex_day.exception_day_type = ex_desc.exception_day_type
@@ -571,7 +573,7 @@ ORDER BY ex_day.date_in_effect ASC;
       return []
     }
 
-    if (date.length > 4) {
+    if (date && date.length > 4) {
       return exceptionDays.filter(({ exceptionDate }) => isEqual(exceptionDate, date))
     }
 


### PR DESCRIPTION
Fixes issues with departures:

- Due to Apollo-Cache, the observed data in the list of departures for a route disappears when switching to the weekly view and back. Added a prefix to the departure ID to differentiate the objects for Apollo.
- Events were matched to departures by day type in the weekly view data, which broke for exception days. Added an alternative date match.
- Departures were missing for some days, for example 28.4.