### PR TITLE
Add simple route data to stops

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -72,6 +72,12 @@
             "description": "",
             "args": [
               {
+                "name": "date",
+                "description": "",
+                "type": { "kind": "SCALAR", "name": "Date", "ofType": null },
+                "defaultValue": null
+              },
+              {
                 "name": "filter",
                 "description": "",
                 "type": { "kind": "INPUT_OBJECT", "name": "StopFilterInput", "ofType": null },
@@ -1885,6 +1891,26 @@
             "deprecationReason": null
           },
           {
+            "name": "routes",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": { "kind": "OBJECT", "name": "SimpleRoute", "ofType": null }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "modes",
             "description": "",
             "args": [],
@@ -1931,6 +1957,53 @@
         ],
         "inputFields": null,
         "interfaces": [{ "kind": "INTERFACE", "name": "Position", "ofType": null }],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SimpleRoute",
+        "description": "",
+        "fields": [
+          {
+            "name": "routeId",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "direction",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Direction", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isTimingStop",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Boolean", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/src/app/createStopsResponse.ts
+++ b/src/app/createStopsResponse.ts
@@ -1,4 +1,11 @@
-import { BBox, SimpleStop, Stop, StopFilterInput, StopRoute } from '../types/generated/schema-types'
+import {
+  BBox,
+  SimpleRoute,
+  SimpleStop,
+  Stop,
+  StopFilterInput,
+  StopRoute,
+} from '../types/generated/schema-types'
 import { JoreLine, JoreRoute, JoreRouteSegment, JoreStop } from '../types/Jore'
 import { cacheFetch } from './cache'
 import { createSimpleStopObject, createStopObject } from './objects/createStopObject'
@@ -10,6 +17,8 @@ import { CachedFetcher } from '../types/CachedFetcher'
 import { getAlerts } from './getAlerts'
 import format from 'date-fns/format'
 import { filterStopsByBBox } from './filters/filterStopsByBBox'
+import { ValidityRange } from '../types/ValidityRange'
+import { Dictionary } from '../types/Dictionary'
 
 // Result from the query is a join of a stop and route segments.
 type JoreCombinedStop = JoreStop & JoreRouteSegment & JoreRoute & JoreLine
@@ -81,6 +90,7 @@ export async function createStopResponse(
 
 export async function createStopsResponse(
   getStops: () => Promise<JoreStop[]>,
+  date?: string,
   filter?: StopFilterInput,
   bbox: BBox | null = null
 ): Promise<SimpleStop[]> {
@@ -91,10 +101,60 @@ export async function createStopsResponse(
       return false
     }
 
-    return fetchedStops.map((stop) => createSimpleStopObject(stop))
+    let stopData = fetchedStops
+
+    if (date && fetchedStops.some(({ date_begin, date_end }) => !!date_begin && !!date_end)) {
+      const filteredStops = filterByDateChains<JoreStop & ValidityRange>(
+        groupBy(stopData, (stop) => stop.stop_id + stop.route_id + stop.direction) as Dictionary<
+          Array<JoreStop & ValidityRange>
+        >,
+        date
+      )
+
+      stopData = filteredStops.reduce((stopsWithRoutes: JoreStop[], stop) => {
+        const existingStop = stopsWithRoutes.find(({ stop_id }) => stop_id === stop.stop_id)
+
+        if (
+          (typeof stop.route_id === 'undefined' || typeof stop.direction === 'undefined') &&
+          !existingStop
+        ) {
+          stop.routes = []
+          stopsWithRoutes.push(stop)
+          return stopsWithRoutes
+        }
+
+        const useStop = existingStop || stop
+        useStop.routes = useStop.routes || []
+
+        const route: SimpleRoute | null = stop.route_id
+          ? {
+              routeId: stop.route_id || '',
+              direction: getDirection(stop.direction),
+              isTimingStop: !!stop.timing_stop_type,
+            }
+          : null
+
+        if (
+          route &&
+          !useStop.routes.find(
+            ({ routeId, direction }) => routeId === route.routeId && direction === route.direction
+          )
+        ) {
+          useStop.routes.push(route)
+        }
+
+        if (!existingStop) {
+          stopsWithRoutes.push(useStop)
+        }
+
+        return stopsWithRoutes
+      }, [])
+    }
+
+    return stopData.map((stop) => createSimpleStopObject(stop))
   }
 
-  const cacheKey = 'stops'
+  const cacheKey = `stops_${date || 'undated'}`
   const stops = await cacheFetch<SimpleStop[]>(cacheKey, fetchStops, 24 * 60 * 60)
 
   if (!stops) {

--- a/src/app/objects/createStopObject.ts
+++ b/src/app/objects/createStopObject.ts
@@ -18,6 +18,7 @@ export function createSimpleStopObject(
     radius: stop.stop_radius,
     modes: mode ? [mode] : [Mode.Bus],
     alerts,
+    routes: stop.routes || [],
     // @ts-ignore
     _matchScore: stop._matchScore,
   }

--- a/src/datasources/JoreDataSource.ts
+++ b/src/datasources/JoreDataSource.ts
@@ -127,9 +127,30 @@ WHERE stop.stop_id = :stopId;`,
     return this.getBatched(query)
   }
 
-  async getStops(): Promise<JoreStop[]> {
-    const query = this.db.raw(
-      `
+  async getStops(date): Promise<JoreStop[]> {
+    const query = date
+      ? this.db.raw(
+          `
+      SELECT stop.stop_id,
+             stop.short_id,
+             stop.lat,
+             stop.lon,
+             stop.name_fi,
+             stop.stop_radius,
+             route_segment.date_begin,
+             route_segment.date_end,
+             route_segment.route_id,
+             route_segment.direction,
+             route_segment.timing_stop_type,
+             modes.modes
+      FROM :schema:.stop stop,
+           :schema:.stop_route_segments_for_date(stop, :date) route_segment,
+           :schema:.stop_modes(stop, :date) modes;
+    `,
+          { schema: SCHEMA, date }
+        )
+      : this.db.raw(
+          `
       SELECT stop.stop_id,
              stop.short_id,
              stop.lat,
@@ -139,8 +160,8 @@ WHERE stop.stop_id = :stopId;`,
              modes.modes
       FROM :schema:.stop stop, :schema:.stop_modes(stop, null) modes;
     `,
-      { schema: SCHEMA }
-    )
+          { schema: SCHEMA }
+        )
 
     return this.getBatched(query)
   }

--- a/src/resolvers/queryResolvers.ts
+++ b/src/resolvers/queryResolvers.ts
@@ -25,14 +25,14 @@ const equipment = (root, { filter, date }, { dataSources }) => {
   return createEquipmentResponse(getEquipment, getObservedVehicles, filter, date)
 }
 
-const stops = (root, { filter }, { dataSources }) => {
-  const getStops = () => dataSources.JoreAPI.getStops()
-  return createStopsResponse(getStops, filter)
+const stops = (root, { filter, date }, { dataSources }) => {
+  const getStops = () => dataSources.JoreAPI.getStops(date)
+  return createStopsResponse(getStops, date, filter)
 }
 
 const stopsByBbox = (root, { filter, bbox }, { dataSources }) => {
   const getStops = () => dataSources.JoreAPI.getStops()
-  return createStopsResponse(getStops, filter, bbox)
+  return createStopsResponse(getStops, '', filter, bbox)
 }
 
 const stop = (root, { stopId, date }, { dataSources }) => {

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -24,7 +24,7 @@ export const Schema = gql`
   type Query {
     equipment(filter: EquipmentFilterInput, date: Date): [Equipment]!
     stop(stopId: String!, date: Date!): Stop
-    stops(filter: StopFilterInput): [SimpleStop]!
+    stops(date: Date, filter: StopFilterInput): [SimpleStop]!
     stopsByBbox(filter: StopFilterInput, bbox: PreciseBBox!): [SimpleStop]!
     route(routeId: String!, direction: Direction!, date: Date!): Route
     routes(filter: RouteFilterInput, line: String, date: Date): [Route]!

--- a/src/schema/Stop.ts
+++ b/src/schema/Stop.ts
@@ -11,6 +11,12 @@ export const Stop = gql`
     mode: String
   }
 
+  type SimpleRoute {
+    routeId: String!
+    direction: Direction!
+    isTimingStop: Boolean!
+  }
+
   type SimpleStop implements Position {
     id: ID!
     stopId: String!
@@ -19,6 +25,7 @@ export const Stop = gql`
     lng: Float!
     name: String
     radius: Float
+    routes: [SimpleRoute!]!
     modes: [String]!
     _matchScore: Float
     alerts: [Alert!]!

--- a/src/types/Jore.ts
+++ b/src/types/Jore.ts
@@ -1,3 +1,5 @@
+import { SimpleRoute } from './generated/schema-types'
+
 export type Maybe<T> = T | null
 
 export enum Mode {
@@ -84,6 +86,12 @@ export interface JoreStop {
   stop_tariff?: Maybe<string>
   point?: Maybe<string>
   modes: Maybe<Mode[]>
+  timing_stop_type?: number
+  route_id?: string
+  direction?: string
+  date_begin?: string
+  date_end?: string
+  routes?: SimpleRoute[]
 }
 
 export interface JoreRoute {

--- a/src/types/generated/resolver-types.ts
+++ b/src/types/generated/resolver-types.ts
@@ -352,6 +352,8 @@ export namespace QueryResolvers {
     StopsArgs
   >
   export interface StopsArgs {
+    date?: Maybe<Date>
+
     filter?: Maybe<StopFilterInput>
   }
 
@@ -882,6 +884,8 @@ export namespace SimpleStopResolvers {
 
     radius?: RadiusResolver<Maybe<number>, TypeParent, TContext>
 
+    routes?: RoutesResolver<SimpleRoute[], TypeParent, TContext>
+
     modes?: ModesResolver<Array<Maybe<string>>, TypeParent, TContext>
 
     _matchScore?: _MatchScoreResolver<Maybe<number>, TypeParent, TContext>
@@ -924,6 +928,11 @@ export namespace SimpleStopResolvers {
     Parent,
     TContext
   >
+  export type RoutesResolver<R = SimpleRoute[], Parent = SimpleStop, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
   export type ModesResolver<
     R = Array<Maybe<string>>,
     Parent = SimpleStop,
@@ -935,6 +944,32 @@ export namespace SimpleStopResolvers {
     TContext
   >
   export type AlertsResolver<R = Alert[], Parent = SimpleStop, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+}
+
+export namespace SimpleRouteResolvers {
+  export interface Resolvers<TContext = {}, TypeParent = SimpleRoute> {
+    routeId?: RouteIdResolver<string, TypeParent, TContext>
+
+    direction?: DirectionResolver<Direction, TypeParent, TContext>
+
+    isTimingStop?: IsTimingStopResolver<boolean, TypeParent, TContext>
+  }
+
+  export type RouteIdResolver<R = string, Parent = SimpleRoute, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type DirectionResolver<R = Direction, Parent = SimpleRoute, TContext = {}> = Resolver<
+    R,
+    Parent,
+    TContext
+  >
+  export type IsTimingStopResolver<R = boolean, Parent = SimpleRoute, TContext = {}> = Resolver<
     R,
     Parent,
     TContext
@@ -2481,6 +2516,7 @@ export type IResolvers<TContext = {}> = {
   StopRoute?: StopRouteResolvers.Resolvers<TContext>
   Alert?: AlertResolvers.Resolvers<TContext>
   SimpleStop?: SimpleStopResolvers.Resolvers<TContext>
+  SimpleRoute?: SimpleRouteResolvers.Resolvers<TContext>
   Route?: RouteResolvers.Resolvers<TContext>
   Cancellation?: CancellationResolvers.Resolvers<TContext>
   RouteGeometry?: RouteGeometryResolvers.Resolvers<TContext>

--- a/src/types/generated/schema-types.ts
+++ b/src/types/generated/schema-types.ts
@@ -401,11 +401,21 @@ export interface SimpleStop extends Position {
 
   radius?: Maybe<number>
 
+  routes: SimpleRoute[]
+
   modes: Array<Maybe<string>>
 
   _matchScore?: Maybe<number>
 
   alerts: Alert[]
+}
+
+export interface SimpleRoute {
+  routeId: string
+
+  direction: Direction
+
+  isTimingStop: boolean
 }
 
 export interface Route {
@@ -851,6 +861,8 @@ export interface StopQueryArgs {
   date: Date
 }
 export interface StopsQueryArgs {
+  date?: Maybe<Date>
+
   filter?: Maybe<StopFilterInput>
 }
 export interface StopsByBboxQueryArgs {


### PR DESCRIPTION
Adds the `routes` prop to SimpleStop, containing simple routeId/direction and timing stop data.