### PR TITLE
Revise journey TLP events ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ssh_tunnel.sh
 greylog_dev.sh
 greylog_stage.sh
 greylog_prod.sh
+.vscode/settings.json

--- a/src/creators/createJourneyResponse.ts
+++ b/src/creators/createJourneyResponse.ts
@@ -658,11 +658,29 @@ export async function createJourneyResponse(
     }
   })
 
-  // Objects with observed data (ie real events) should be ordered by timestamp.
-  const sortedJourneyEvents: EventsType[] = orderBy(
-    [...stopEventObjects, ...journeyEventObjects, ...tlrEvents, ...tlaEvents],
-    '_sort'
-  )
+  // Sort observed (ie real) events by timestamp, but also with additional logic as (old) timestamps do not include milliseconds
+  const sortedJourneyEvents: EventsType[] = [
+    ...stopEventObjects,
+    ...journeyEventObjects,
+    ...tlrEvents,
+    ...tlaEvents,
+  ].sort((eventA, eventB) => {
+    if (eventA._sort && eventB._sort) {
+      const sort = eventA._sort - eventB._sort
+      if (sort === 0) {
+        // order TLA event after TLR
+        if (eventA.type === 'TLA' && eventB.type === 'TLR') {
+          return 1
+        } else {
+          return -1
+        }
+      } else {
+        return sort
+      }
+    } else {
+      return -1
+    }
+  })
 
   // Get the time info from an event.
   const getTimeFromEvent = (event: EventsType): number => {

--- a/src/creators/createJourneyResponse.ts
+++ b/src/creators/createJourneyResponse.ts
@@ -88,6 +88,9 @@ const isPlannedEvent = (event: any): event is PlannedStopEvent => event.type ===
 const isStopEvent = (event: any): event is PlannedStopEvent | JourneyStopEvent =>
   typeof event.index !== 'undefined'
 
+const isTlpEvent = (event: any): event is JourneyTlpEvent =>
+  typeof event.requestId !== 'undefined'
+
 /**
  * Fetch the journey events and filter out the invalid ones.
  * @param fetcher async function that fetches the journey events
@@ -668,8 +671,13 @@ export async function createJourneyResponse(
     if (eventA._sort && eventB._sort) {
       const sort = eventA._sort - eventB._sort
       if (sort === 0) {
-        // order TLA event after TLR
         if (eventA.type === 'TLA' && eventB.type === 'TLR') {
+          // order TLA event after TLR
+          return 1
+        } else if (eventA.type === 'TLR' && eventB.type === 'TLA') {
+          return -1
+        } else if (isTlpEvent(eventA) && !isTlpEvent(eventB)) {
+          // order TLP events after other events with same timestamp
           return 1
         } else {
           return -1

--- a/src/objects/createJourneyEventObject.ts
+++ b/src/objects/createJourneyEventObject.ts
@@ -239,7 +239,7 @@ export function createJourneyTlpEventObject(event: TlpEvents): JourneyTlpEvent {
     lng: event.long,
     loc: event.loc,
     // Sort TLA events after TLR events
-    _sort: event.event_type === 'TLA' ? unix + 1 : unix,
+    _sort: unix,
   }
 }
 


### PR DESCRIPTION
**If two or more events have the same timestamp...**

- Order TLA after TLR event
- Order TLP events after other events (groups TLP events together)